### PR TITLE
added transparent background for ios 6

### DIFF
--- a/RKTabView/RKTabView.m
+++ b/RKTabView/RKTabView.m
@@ -213,6 +213,7 @@
             textColor = self.titlesFontColor;
         }
         titleLabel.textColor = textColor;
+        titleLabel.backgroundColor = [UIColor clearColor];
         
         titleSize = [tabItem.titleString sizeWithFont:titleLabel.font constrainedToSize:CGSizeMake(tab.bounds.size.width, MAXFLOAT) lineBreakMode:NSLineBreakByWordWrapping];
         titleLabel.text = tabItem.titleString;


### PR DESCRIPTION
Added transparent background for lte iOS6. Otherwise the label will have a white background :)

Would you be so kind and update the version also to 1.0.1? :)

Thank you very much.
