### PR TITLE
Fixed setting correct background color for tab item

### DIFF
--- a/RKTabView/RKTabView.m
+++ b/RKTabView/RKTabView.m
@@ -275,7 +275,7 @@
             tab.backgroundColor = self.enabledTabBackgrondColor;
         }
     } else {
-        tab.backgroundColor = tabItem.backgroundColor;
+        tab.backgroundColor = tabItem.backgroundColor ? tabItem.backgroundColor : [UIColor clearColor];
     }
 }
 


### PR DESCRIPTION
Fixed setting correct background color for tab item. Otherwise background color is ignored by view.